### PR TITLE
Add daily resilience metrics

### DIFF
--- a/config/metrics.yml
+++ b/config/metrics.yml
@@ -211,25 +211,25 @@ categories:
   labels: *common_labels
   metrics:
   - name: contributors_sleep_recovery
-    desc: Contribution of sleep recovery in range [1, 100].
+    desc: "Sleep recovery contributor to the resilience score. Range: [0, 100]"
     type: gauge
     unit: pt
     labels: *common_labels
     iterator: contributors.sleep_recovery
   - name: contributors_daytime_recovery
-    desc: Contribution of daytime recovery in range [1, 100].
+    desc: "Daytime recovery contributor to the resilience score. Range: [0, 100]"
     type: gauge
     unit: pt
     labels: *common_labels
     iterator: contributors.daytime_recovery
   - name: contributors_stress
-    desc: Contribution of stress in range [1, 100].
+    desc: "Stress contributor to the resilience score. Range: [0, 100]"
     type: gauge
     unit: pt
     labels: *common_labels
     iterator: contributors.stress
   - name: level
-    desc: Daily resilience level.("limited", "adequate", "solid", "strong", "exceptional")
+    desc: Resilience level.("limited", "adequate", "solid", "strong", "exceptional")
     type: info
     labels: *common_labels
 - name: daily_sleep

--- a/config/metrics.yml
+++ b/config/metrics.yml
@@ -206,6 +206,32 @@ categories:
     type: gauge
     unit: celsius
     labels: *common_labels
+- name: daily_resilience
+  prefix: oura_daily_resilience_
+  labels: *common_labels
+  metrics:
+  - name: contributors_sleep_recovery
+    desc: Contribution of sleep recovery in range [1, 100].
+    type: gauge
+    unit: pt
+    labels: *common_labels
+    iterator: contributors.sleep_recovery
+  - name: contributors_daytime_recovery
+    desc: Contribution of daytime recovery in range [1, 100].
+    type: gauge
+    unit: pt
+    labels: *common_labels
+    iterator: contributors.daytime_recovery
+  - name: contributors_stress
+    desc: Contribution of stress in range [1, 100].
+    type: gauge
+    unit: pt
+    labels: *common_labels
+    iterator: contributors.stress
+  - name: level
+    desc: Daily resilience level.("limited", "adequate", "solid", "strong", "exceptional")
+    type: info
+    labels: *common_labels
 - name: daily_sleep
   prefix: oura_daily_sleep_
   labels: *common_labels

--- a/example/oura.prom
+++ b/example/oura.prom
@@ -109,6 +109,18 @@ oura_daily_readiness_temperature_deviation{email="DUMMY@icloud.com"} -0.13
 # HELP oura_daily_readiness_temperature_trend_deviation Temperature trend deviation in degrees Celsius.
 # TYPE oura_daily_readiness_temperature_trend_deviation gauge
 oura_daily_readiness_temperature_trend_deviation{email="DUMMY@icloud.com"} -0.1
+# HELP oura_daily_resilience_contributors_sleep_recovery Contribution of sleep recovery [1, 100].
+# TYPE oura_daily_resilience_contributors_sleep_recovery gauge
+oura_daily_resilience_contributors_sleep_recovery{email="DUMMY@icloud.com"} 98.0
+# HELP oura_daily_resilience Contribution of daytime recovery [1, 100].
+# TYPE oura_daily_resilience_contributors_daytime_recovery gauge
+oura_daily_resilience_contributors_daytime_recovery{email="DUMMY@icloud.com"} 98.0
+# HELP oura_daily_resilience Contribution of stress [1, 100].
+# TYPE oura_daily_resilience_contributors_stress gauge
+oura_daily_resilience_contributors_stress{email="DUMMY@icloud.com"} 98.0
+# HELP oura_daily_resilience_level Resilience level. Possible daily resilience levels.("limited", "adequate", "solid", "strong", "exceptional")
+# TYPE oura_daily_resilience_level gauge
+oura_daily_resilience_level{email="DUMMY@icloud.com"} solid
 # HELP oura_daily_sleep_contributors_deep_sleep Contribution of deep sleep in range [1, 100].
 # TYPE oura_daily_sleep_contributors_deep_sleep gauge
 oura_daily_sleep_contributors_deep_sleep{email="DUMMY@icloud.com"} 98.0

--- a/example/oura.prom
+++ b/example/oura.prom
@@ -109,18 +109,18 @@ oura_daily_readiness_temperature_deviation{email="DUMMY@icloud.com"} -0.13
 # HELP oura_daily_readiness_temperature_trend_deviation Temperature trend deviation in degrees Celsius.
 # TYPE oura_daily_readiness_temperature_trend_deviation gauge
 oura_daily_readiness_temperature_trend_deviation{email="DUMMY@icloud.com"} -0.1
-# HELP oura_daily_resilience_contributors_sleep_recovery Contribution of sleep recovery [1, 100].
+# HELP oura_daily_resilience_contributors_sleep_recovery Sleep recovery contributor to the resilience score. Range: [0, 100]
 # TYPE oura_daily_resilience_contributors_sleep_recovery gauge
-oura_daily_resilience_contributors_sleep_recovery{email="DUMMY@icloud.com"} 98.0
-# HELP oura_daily_resilience Contribution of daytime recovery [1, 100].
+oura_daily_resilience_contributors_sleep_recovery{email="DUMMY@icloud.com"} 54.7
+# HELP oura_daily_resilience_contributors_daytime_recovery Daytime recovery contributor to the resilience score. Range: [0, 100]
 # TYPE oura_daily_resilience_contributors_daytime_recovery gauge
-oura_daily_resilience_contributors_daytime_recovery{email="DUMMY@icloud.com"} 98.0
-# HELP oura_daily_resilience Contribution of stress [1, 100].
+oura_daily_resilience_contributors_daytime_recovery{email="DUMMY@icloud.com"} 49.9
+# HELP oura_daily_resilience_contributors_stress Stress contributor to the resilience score. Range: [0, 100]
 # TYPE oura_daily_resilience_contributors_stress gauge
-oura_daily_resilience_contributors_stress{email="DUMMY@icloud.com"} 98.0
-# HELP oura_daily_resilience_level Resilience level. Possible daily resilience levels.("limited", "adequate", "solid", "strong", "exceptional")
-# TYPE oura_daily_resilience_level gauge
-oura_daily_resilience_level{email="DUMMY@icloud.com"} solid
+oura_daily_resilience_contributors_stress{email="DUMMY@icloud.com"} 51.4
+# HELP oura_daily_resilience_level_info Resilience level.("limited", "adequate", "solid", "strong", "exceptional")
+# TYPE oura_daily_resilience_level_info gauge
+oura_daily_resilience_level_info{email="DUMMY@icloud.com",val="solid"} 1.0
 # HELP oura_daily_sleep_contributors_deep_sleep Contribution of deep sleep in range [1, 100].
 # TYPE oura_daily_sleep_contributors_deep_sleep gauge
 oura_daily_sleep_contributors_deep_sleep{email="DUMMY@icloud.com"} 98.0

--- a/main.py
+++ b/main.py
@@ -52,6 +52,8 @@ if __name__ == "__main__":
                 metrics = oura.get_daily_activity(yesterday, today)
             elif category.name == 'daily_readiness':
                 metrics = oura.get_daily_readiness(today, today)
+            elif category.name == 'daily_resilience':
+                metrics = oura.get_daily_resilience(today, today)
             elif category.name == 'daily_sleep':
                 metrics = oura.get_daily_sleep(today, today)
             elif category.name == 'daily_spo2':

--- a/modules/oura.py
+++ b/modules/oura.py
@@ -46,6 +46,12 @@ class Oura:
             return from_dict(data_class=OuraDailyReadinesses, data=res_dict, config=self.cast_config)
         return None
 
+    def get_daily_resilience(self, start_date:datetime.date, end_date:datetime.date) -> OuraDailyResiliences:
+        res_dict = self.get_usercollection("daily_resilience", start_date=start_date, end_date=end_date)
+        if res_dict != None:
+            return from_dict(data_class=OuraDailyResiliences, data=res_dict, config=self.cast_config)
+        return None
+
     def get_daily_sleep(self, start_date:datetime.date, end_date:datetime.date) -> OuraDailySleeps:
         res_dict = self.get_usercollection("daily_sleep", start_date=start_date, end_date=end_date)
         if res_dict != None:

--- a/modules/oura_dataclasses.py
+++ b/modules/oura_dataclasses.py
@@ -77,6 +77,24 @@ class OuraDailyReadinesses:
     next_token: str | None
 
 @dataclass
+class OuraDailyResilienceContributors:
+    sleep_recovery: float
+    daytime_recovery: float
+    stress: float
+
+@dataclass
+class OuraDailyResilience:
+    id: str
+    contributors: OuraDailyResilienceContributors
+    day: datetime.date
+    level: str
+
+@dataclass
+class OuraDailyResiliences:
+    data: list[OuraDailyResilience]
+    next_token: str | None
+
+@dataclass
 class OuraDailySleepContributors:
     deep_sleep: int
     efficiency: int


### PR DESCRIPTION
## Description

Add daily resilience metrics:
  oura_daily_resilience_level
  oura_daily_resilience_contributors_sleep_recovery
  oura_daily_resilience_contributors_daytime_recovery
  oura_daily_resilience_contributors_stress

## Motivation and Context

The exporter isn't updated since the addition of resilience to Oura

## How Has This Been Tested?

Manually verifying the metrics in the exporter with data from the oura API. Additional verification would not hurt.

## Appendix

https://cloud.ouraring.com/v2/docs#tag/Daily-Resilience-Routes

Hope I didn't miss anything :) 