### PR TITLE
fix: update Oura exporter for API v2 compatibility

### DIFF
--- a/modules/oura.py
+++ b/modules/oura.py
@@ -35,43 +35,43 @@ class Oura:
             return None
 
     def get_daily_activity(self, start_date:datetime.date, end_date:datetime.date) -> OuraDailyActivities:
-        res_dict = self.get_usercollection("daily_activity", start_date=start_date, end_date=end_date)
+        res_dict = self.get_usercollection("daily_activity", start_date=start_date.isoformat(), end_date=end_date.isoformat())
         if res_dict != None:
             return from_dict(data_class=OuraDailyActivities, data=res_dict, config=self.cast_config)
         return None
 
     def get_daily_readiness(self, start_date:datetime.date, end_date:datetime.date) -> OuraDailyReadinesses:
-        res_dict = self.get_usercollection("daily_readiness", start_date=start_date, end_date=end_date)
+        res_dict = self.get_usercollection("daily_readiness", start_date=start_date.isoformat(), end_date=end_date.isoformat())
         if res_dict != None:
             return from_dict(data_class=OuraDailyReadinesses, data=res_dict, config=self.cast_config)
         return None
 
     def get_daily_resilience(self, start_date:datetime.date, end_date:datetime.date) -> OuraDailyResiliences:
-        res_dict = self.get_usercollection("daily_resilience", start_date=start_date, end_date=end_date)
+        res_dict = self.get_usercollection("daily_resilience", start_date=start_date.isoformat(), end_date=end_date.isoformat())
         if res_dict != None:
             return from_dict(data_class=OuraDailyResiliences, data=res_dict, config=self.cast_config)
         return None
 
     def get_daily_sleep(self, start_date:datetime.date, end_date:datetime.date) -> OuraDailySleeps:
-        res_dict = self.get_usercollection("daily_sleep", start_date=start_date, end_date=end_date)
+        res_dict = self.get_usercollection("daily_sleep", start_date=start_date.isoformat(), end_date=end_date.isoformat())
         if res_dict != None:
             return from_dict(data_class=OuraDailySleeps, data=res_dict, config=self.cast_config)
         return None
 
     def get_daily_spo2(self, start_date:datetime.date, end_date:datetime.date) -> OuraDailySpo2s:
-        res_dict = self.get_usercollection("daily_spo2", start_date=start_date, end_date=end_date)
+        res_dict = self.get_usercollection("daily_spo2", start_date=start_date.isoformat(), end_date=end_date.isoformat())
         if res_dict != None:
             return from_dict(data_class=OuraDailySpo2s, data=res_dict, config=self.cast_config)
         return None
 
     def get_daily_stress(self, start_date:datetime.date, end_date:datetime.date) -> OuraDailyStresses:
-        res_dict = self.get_usercollection("daily_stress", start_date=start_date, end_date=end_date)
+        res_dict = self.get_usercollection("daily_stress", start_date=start_date.isoformat(), end_date=end_date.isoformat())
         if res_dict != None:
             return from_dict(data_class=OuraDailyStresses, data=res_dict, config=self.cast_config)
         return None
 
     def get_heartrate(self, start_datetime:datetime.datetime, end_datetime:datetime.datetime) -> OuraHeartRates:
-        res_dict = self.get_usercollection("heartrate", start_datetime=start_datetime, end_datetime=end_datetime)
+        res_dict = self.get_usercollection("heartrate", start_datetime=start_datetime.isoformat(), end_datetime=end_datetime.isoformat())
         if res_dict != None:
             return from_dict(data_class=OuraHeartRates, data=res_dict, config=self.cast_config)
         return None


### PR DESCRIPTION
## Description
The Oura API v2 deprecates certain features and has different date format requirements from v1. These changes address several issues:

1. Ensure proper ISO 8601 date formatting for all API requests
2. Extend date ranges to improve data availability (7-day lookback)
3. Fix attribute access for heartrate data which uses timestamp instead of day
4. Add better error handling and logging for troubleshooting

These fixes are necessary since Oura API v1 was discontinued in early 2023, and the v2 API requires proper authorization headers and date formats to function correctly.

## Motivation and Context

This change fixes https://github.com/legnoh/oura-exporter/issues/24


## How Has This Been Tested?

I built test Docker images with my code changes and compared their metric scrapes with the latest legnoh/oura-exporter (1c8b9d994c70). All of my metrics pull from the API now without any warnings or failures.

