### PR TITLE
Potential fix for code scanning alert no. 15: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/legnoh/oura-exporter/security/code-scanning/15](https://github.com/legnoh/oura-exporter/security/code-scanning/15)

To fix the problem, we must add a `permissions` block at either the root workflow level (to apply to all jobs) or within the affected job definition (the `ci` job). As only one job is present and no other jobs are defined, it is best practice and more succinct to add `permissions:` at the root of the workflow. The minimal best-practice permission is `contents: read`, enabling jobs to read repository contents without granting excess access. This should be placed after the `name:` and before any jobs or triggers.

In .github/workflows/ci.yml, add:
```yaml
permissions:
  contents: read
```
directly after the workflow name and before the `on:` section.

No imports or new dependencies are required for this change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
